### PR TITLE
Run GHDL in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,33 @@ Learn VHDL by example in a web browser (for Tufts ES 4 and EE 201)
 Requires flask, flask-markdown, and gunicorn, install using pip:
 `pip install flask flask-markdown gunicorn`.
 
-Must also have [GHDL](https://github.com/ghdl/ghdl) installed.
+Must also have [GHDL](https://github.com/ghdl/ghdl) installed (not required when using docker).
+
+Must also have [docker](https://www.docker.com/) installed. Will automatically pull/update image.
 
 Make sure you have an appropriate `deploy.config` and `debug.config` before running `deploy` and `debug`, respectively.
 
 Useful resources:
 * https://www.vultr.com/docs/how-to-setup-gunicorn-to-serve-python-web-applications
+
+## Docker
+
+Pull the latest GHDL docker image using:
+```
+docker pull ghdl/ghdl:buster-gcc-8.3.0
+```
+
+Pass in files/folders to a docker container by doing:
+```
+docker run -v /local/path/to/folder:/container/path/to/folder <container> [command]
+```
+
+Automatically delete a container when finished by passing in `--rm`:
+```
+docker run --rm <container> [command]
+```
+
+To run GHDL from docker, do:
+```
+docker run ghdl/ghdl:buster-gcc-8.3.0 ghdl <stuff>
+```

--- a/template.config
+++ b/template.config
@@ -20,3 +20,6 @@ WORKDIR="/tmp/vhdlweb"
 # This is most useful for specifying the GHDL path
 #MAKE_ARGS = ["GHDL=/home/steven/tools/ghdl/ghdl_mcode"]
 MAKE_ARGS = []
+
+# Specify the docker image for GHDL
+DOCKER_IMAGE = "ghdl/ghdl:buster-gcc-8.3.0"

--- a/vhdlweb_build.py
+++ b/vhdlweb_build.py
@@ -61,15 +61,17 @@ def runtest(wdir, problem):
     wdir: The working directory to copy to and build in
     problem: the id for the problem we're working on
     """
- 
+
     # Copy the files into the working directory
     try:
       filelist = open("{path}/{problem}/filelist".format(path=current_app.config['SRCDIR'], problem=problem))
       for filename in filelist:
         safe_run(["cp", "{path}/{problem}/{filename}".format(path=current_app.config['SRCDIR'], problem=problem, filename=filename.strip()), wdir])
 
-      # Try to jam it through GHDL and capture the result
-      output = safe_run(["make", "-f", wdir + "Makefile", "--directory", wdir, "--silent"] + current_app.config['MAKE_ARGS'], stderr = sp.STDOUT)
+        # Try to jam it through docker GHDL and capture the result
+      command = ["docker", "run", "--rm", "-v", wdir + ":" + wdir, current_app.config["DOCKER_IMAGE"]]
+      safe_run(["docker", "pull", current_app.config["DOCKER_IMAGE"]])
+      output = safe_run(command + ["make", "-f", wdir + "Makefile", "--directory", wdir, "--silent"] + current_app.config['MAKE_ARGS'], stderr = sp.STDOUT)
       output = output.decode('utf-8')
     except Exception as e:
       current_app.logger.error("server error with wdir=" + wdir + " :\n" + str(e))
@@ -92,4 +94,3 @@ def runtest(wdir, problem):
 
     return {"status":status, "buildOutput":output}
     return output
-

--- a/vhdlweb_build.py
+++ b/vhdlweb_build.py
@@ -29,7 +29,7 @@ def findpath(workdir, student, problemId):
   # This should only happen for anonymous users
   studentpath = workdir + '/' + student
   if not os.path.isdir(studentpath):
-    os.mkdir(studentpath)
+    os.makedirs(studentpath)
 
   # Check that the problem subdirectory exists and create it if necessary
   # This will happen the first time a user attempts a problem
@@ -83,7 +83,7 @@ def runtest(wdir, problem):
     # See if the testbench emitted a "TEST PASSED" line
     passMatches = re.findall('TEST PASSED', output)
 
-    testPassed = len(passMatches) is 1
+    testPassed = len(passMatches) == 1
 
     if buildOk and testPassed:
       status = "pass"

--- a/vhdlweb_build.py
+++ b/vhdlweb_build.py
@@ -70,7 +70,7 @@ def runtest(wdir, problem):
 
         # Try to jam it through docker GHDL and capture the result
       command = ["docker", "run", "--rm", "-v", wdir + ":" + wdir, current_app.config["DOCKER_IMAGE"]]
-      safe_run(["docker", "pull", current_app.config["DOCKER_IMAGE"]])
+      safe_run(["docker", "pull", current_app.config["DOCKER_IMAGE"]], timeout=120)
       output = safe_run(command + ["make", "-f", wdir + "Makefile", "--directory", wdir, "--silent"] + current_app.config['MAKE_ARGS'], stderr = sp.STDOUT)
       output = output.decode('utf-8')
     except Exception as e:


### PR DESCRIPTION
Replace the locally-installed version of GHDL with a containerized version.  This takes significantly longer to run (~1 second versus almost instantaneous) but solves nearly all of the security issues and makes it easy to keep GHDL up to date along with Yosys and other tools.