### PR TITLE
Catch and fix unicode input

### DIFF
--- a/data/problems/customskin.svg
+++ b/data/problems/customskin.svg
@@ -343,7 +343,6 @@ line {
   </g>
 
   <g s:type="generic" transform="translate(550,250)" s:width="30" s:height="40">
-    <s:alias val="generic-bus"/>
 
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">generic</text>
     <rect width="30" height="40" s:generic="body" class="$cell_id"/>

--- a/templates/problem.html
+++ b/templates/problem.html
@@ -68,7 +68,6 @@ function compile(buttonId) {
 
   // check for other weird characters and stop of they exist
   code = code.replace(/[^\x00-\x7F]/g, "");
-  console.log(code_clean);
   if (code !== code_clean) {
       var diffLine = findDiffLine(code, code_clean);
       outputlog.innerHTML = `Cannot replace non-ASCII character on line ${diffLine}!`;

--- a/templates/problem.html
+++ b/templates/problem.html
@@ -35,6 +35,17 @@ function rollback(submissionId) {
       xmlhttp.send();
 }
 
+function findDiffLine(str1, str2) {
+    let line = 1;
+    for (i = 0; i < str2.length; i++) {
+        if (str2.charAt(i) !== str1.charAt(i))
+            return line;
+        if (str1.charAt(i) === "\n")
+            line++;
+    }
+    return -1;
+}
+
 function compile(buttonId) {
   // Set the build text to "building"
   outputlog = document.getElementById("buildlog");
@@ -44,6 +55,25 @@ function compile(buttonId) {
 
   // Read the code from the form
   var code = editor.getValue();
+  var code_clean = code;
+
+  // Replace &nbsp; space with normal space
+  code = code.replace(/\u00a0/g, ' ');
+  if (code !== code_clean) {
+      var diffLine = findDiffLine(code, code_clean);
+      outputlog.innerHTML = `Replaced nbsp on line ${diffLine} with normal space`;
+      editor.setValue(code);
+      code_clean = code;
+  }
+
+  // check for other weird characters and stop of they exist
+  code = code.replace(/[^\x00-\x7F]/g, "");
+  console.log(code_clean);
+  if (code !== code_clean) {
+      var diffLine = findDiffLine(code, code_clean);
+      outputlog.innerHTML = `Cannot replace non-ASCII character on line ${diffLine}!`;
+      return;
+  }
 
   // Send the code to the server
   if (code.length == 0) {
@@ -111,7 +141,7 @@ function compile(buttonId) {
 &#9654;
 </span>
 {% elif s['status'] == 'pass' %}
-&#9989; 
+&#9989;
 {% endif %}
 </a>
 {% endfor %}


### PR DESCRIPTION
Fixes #5 by automatically replacing `&nbsp;` with a normal space, and for all other non-ASCII characters, it halts and lets the user know which line the non-ASCII character is on so no non-ASCII code is sent to the server. Tested with emojis and `&nbsp;`.

Also fixes a bug within `data/problems/customskin.svg` regarding having the generic-bus alias for the generic symbol, which prevented generics from having their types above the symbol, instead just putting the internal name (i.e. `\13`).